### PR TITLE
Agrega condiciones a filtros de búsqueda de actividades

### DIFF
--- a/app/Search/ActividadesSearch.php
+++ b/app/Search/ActividadesSearch.php
@@ -43,8 +43,12 @@ class ActividadesSearch
         $query->join('Tipo', 'Actividad.idTipo', '=', 'Tipo.idTipo')
             ->leftJoin('PuntoEncuentro', 'Actividad.idActividad', '=', 'PuntoEncuentro.idActividad')
             ->selectRaw('distinct Actividad.*')
-            ->orderBy('fechaInicio', 'desc');
-
+            ->orderBy('fechaInicio', 'desc')
+            ->where('estadoConstruccion', 'Abierta')
+            ->where('inscripcionInterna', 0) //Visibilidad pública
+            ->whereDate('fechaInicioInscripciones', '<=', date('Y-m-d'))
+            ->whereDate('fechaFinInscripciones', '>=', date('Y-m-d'))
+            ->whereDate('fechaInicio', '>=', date('Y-m-d'));
         return $query;
     }
 }

--- a/app/Search/LocalidadesSearch.php
+++ b/app/Search/LocalidadesSearch.php
@@ -44,7 +44,12 @@ class LocalidadesSearch
             ->orderBy('atl_provincias.Provincia', 'asc')
             ->orderBy('atl_localidades.Localidad', 'asc')
             ->selectRaw('distinct atl_provincias.id id_provincia, atl_provincias.Provincia, 
-                                         atl_localidades.id id_localidad, atl_localidades.Localidad');
+                                         atl_localidades.id id_localidad, atl_localidades.Localidad')
+            ->where('estadoConstruccion', 'Abierta')
+            ->where('inscripcionInterna', 0) //Visibilidad pública
+            ->whereDate('fechaInicioInscripciones', '<=', date('Y-m-d'))
+            ->whereDate('fechaFinInscripciones', '>=', date('Y-m-d'))
+            ->whereDate('fechaInicio', '>=', date('Y-m-d'));
         return $query;
     }
 }

--- a/app/Search/TiposActividadesSearch.php
+++ b/app/Search/TiposActividadesSearch.php
@@ -41,7 +41,12 @@ class TiposActividadesSearch
         $query->join('Tipo', 'Actividad.idTipo', '=', 'Tipo.idTipo')
             ->leftJoin('PuntoEncuentro', 'Actividad.idActividad', '=', 'PuntoEncuentro.idActividad')
             ->orderBy('Tipo.nombre', 'asc')
-            ->selectRaw('distinct Tipo.idTipo, Tipo.nombre');
+            ->selectRaw('distinct Tipo.idTipo, Tipo.nombre')
+            ->where('estadoConstruccion', 'Abierta')
+            ->where('inscripcionInterna', 0) //Visibilidad pública
+            ->whereDate('fechaInicioInscripciones', '<=', date('Y-m-d'))
+            ->whereDate('fechaFinInscripciones', '>=', date('Y-m-d'))
+            ->whereDate('fechaInicio', '>=', date('Y-m-d'));
         return $query;
     }
 }


### PR DESCRIPTION
Ahora para que una actividad aparezca en los filtros, la misma deberá cumplir estos requisitos:

- Debe ser pública (columna inscripcionInterna = 0)
- Debe estar Abierta (columna estadoConstruccion)
- Fecha Inicio Inscripciones >= HOY <= Fecha Fin Inscripciones
- Fecha Inicio Actividad >= HOY 