### PR TITLE
Agrega page 403 dead simple

### DIFF
--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,9 +1,15 @@
 @extends('main')
 
 @section('main_content')
-        <div class="">
-            <div class="row d-flex justify-content-center">
-                <h1 class="text-primary">No autorizado</h1>
-            </div>
+    <div class="">
+        <div class="row d-flex justify-content-center">
+            <h1 class="text-primary">Oops! Vuelve y busca otra ruta</h1>
         </div>
+        <div class="row d-flex justify-content-center">
+            <img src="/img/404.png" alt="404">
+        </div>
+        <div class="row d-flex justify-content-center">
+            <button class="btn btn-primary btn-lg" onclick="window.history.go(-1); return false;"><i class="fas fa-arrow-circle-left"></i> ATRÁS</button>
+        </div>
+    </div>
 @endsection


### PR DESCRIPTION
No hay mucho que decir. Tratar de entrar a una página a la que no tienen permiso, como por ejemplo /admin/actividades/usuario y debería mostrar la página de 404 con un botón para regresar a donde estaban antes.