### PR TITLE
Fix bug tipo actividad

### DIFF
--- a/app/Http/Controllers/backoffice/ActividadesController.php
+++ b/app/Http/Controllers/backoffice/ActividadesController.php
@@ -131,7 +131,14 @@ class ActividadesController extends Controller
             }
 
             $categorias = CategoriaActividad::all();
-            $tipos = $actividad->tipo->categoria->tipos;
+
+            try {
+                $tipos = $actividad->tipo->categoria->tipos;
+            } catch (\Exception $e) {
+                $actividad->tipo->categoria = null;
+                $tipos = null;
+            }
+
             try {
                 $provincias = $actividad->pais->provincias;
                 $localidades = $actividad->provincia->localidades;


### PR DESCRIPTION
Corrige un bug que ocurre al mostrar en la vista de actividad del backoffice una actividad de Pilote cuyo Tipo no tiene una categoria asociada, por tratarse de un tipo de actividad obsoleto. 

Ejemplo de actividad con bug: 2291.

Probar antes y después de pasarse a este branch.