### PR TITLE
TEC-274 Quita toolbar erroneo y quita botones de datatables

### DIFF
--- a/config/datatables.php
+++ b/config/datatables.php
@@ -61,12 +61,12 @@ return [
             //   callback' => 'allcap'
             // ],
             // [
-            [
-                'name' => '__component:mis-actividades',
-                'title' => 'Acciones',
-                'titleClass' => 'text-center',
-                'dataClass' => 'text-center'
-            ]
+//            [
+//                'name' => '__component:mis-actividades',
+//                'title' => 'Acciones',
+//                'titleClass' => 'text-center',
+//                'dataClass' => 'text-center'
+//            ]
         ],
         'sortOrder' => [
             [
@@ -135,12 +135,12 @@ return [
             //   callback' => 'allcap'
             // ],
             // [
-            [
-                'name' => '__component:mis-actividades',
-                'title' => 'Acciones',
-                'titleClass' => 'text-center',
-                'dataClass' => 'text-center'
-            ]
+//            [
+//                'name' => '__component:mis-actividades',
+//                'title' => 'Acciones',
+//                'titleClass' => 'text-center',
+//                'dataClass' => 'text-center'
+//            ]
         ],
         'sortOrder' => [
             [

--- a/resources/assets/js/components/backoffice/grupos/MiembrosTabla.vue
+++ b/resources/assets/js/components/backoffice/grupos/MiembrosTabla.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <filter-bar v-bind:placeholder-text="dataPlaceholderText" ref="gruposToolbar"></filter-bar>
+    <grupos-filter-bar v-bind:placeholder-text="dataPlaceholderText" ref="gruposToolbar"></grupos-filter-bar>
     <vuetable-miembros
       class="vuetable"
       ref="vuetableMiembros"
@@ -45,7 +45,7 @@
   Vue.use(VueEvents);
   Vue.component('custom-actions', CustomActions);
   Vue.component('my-detail-row', DetailRow);
-  Vue.component('filter-bar', GruposFilterBar);
+  Vue.component('grupos-filter-bar', GruposFilterBar);
 
 export default {
     components: {

--- a/routes/web.php
+++ b/routes/web.php
@@ -117,7 +117,7 @@ Route::prefix('/admin')->middleware(['auth', 'can:accesoBackoffice'])->group(fun
     Route::delete('/actividades/{id}', 'backoffice\ActividadesController@destroy')->middleware('can:borrar,App\Actividad,id');
     Route::get('/actividades/{id}/editar', 'backoffice\ActividadesController@edit')->middleware('can:editar,App\Actividad,id');
     Route::post('/actividades/{id}/editar', 'backoffice\ActividadesController@update')->middleware('can:editar,App\Actividad,id');
-    Route::get('/actividades/{id}/inscripciones', 'backoffice\InscripcionesController@index')->middleware('can:verInscripciones,App\Inscripcion,id');
+    //Route::get('/actividades/{id}/inscripciones', 'backoffice\InscripcionesController@index')->middleware('can:verInscripciones,App\Inscripcion,id'); // En desuso
     Route::get('/actividades/{id}/inscripciones/exportar', 'backoffice\ReportController@exportarInscripciones')->middleware('can:verInscripciones,App\Inscripcion,id');
     Route::get('/ajax/actividades/{id}/inscripciones', 'backoffice\ajax\InscripcionesController@index')->middleware('can:verInscripciones,App\Inscripcion,id');
     Route::post('/ajax/actividades/{id}/inscripciones', 'backoffice\ajax\InscripcionesController@store')->middleware('can:verInscripciones,App\Inscripcion,id');


### PR DESCRIPTION
Quita toolbar erroneo de vistas Mis Actividades y "Ver Todas". También quita los botones de acceso a Inscripciones (obsoleto) y la lupa para ver el detalle de actividad (se accede clickeando la fila).